### PR TITLE
⚡ Bolt: Cache vector matrix in MatryoshkaIndexer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2024-05-22 - Python Package Name Conflict
+**Learning:** The project uses a package named `antigravity`, which conflicts with a standard library module. This caused import errors during benchmarking until `sys.path` was manipulated and `sys.modules` cleaned.
+**Action:** When working with Python projects, check for package name conflicts with stdlib early. If found, ensure `sys.path` prioritization is correct or use relative imports carefully.
+
+## 2024-05-22 - Matrix Re-computation Overhead
+**Learning:** `MatryoshkaIndexer` was re-stacking numpy arrays from a dictionary on every search. For 50k vectors, this added ~0.1s overhead per search (37% of total time).
+**Action:** Always cache derived data structures (like matrices) if the underlying data (index) changes infrequently compared to read operations.

--- a/antigravity-logicware/src/antigravity/k3_mrl_indexer.py
+++ b/antigravity-logicware/src/antigravity/k3_mrl_indexer.py
@@ -41,6 +41,8 @@ class MatryoshkaIndexer:
         self.index: Dict[str, Dict[str, Any]] = {}
         self.failed_files: List[str] = []
         self._unsaved_changes = 0
+        self._matrix_cache = None
+        self._paths_cache = None
         self.load_index()
 
     def load_index(self):
@@ -68,6 +70,10 @@ class MatryoshkaIndexer:
                 self.index = {}
         else:
             print(f"[SYSTEM] No index found at {self.index_file}. Initializing new.")
+
+        # Invalidate cache
+        self._matrix_cache = None
+        self._paths_cache = None
 
     def save_index(self):
         """Atomic binary save to prevent corruption."""
@@ -338,6 +344,9 @@ class MatryoshkaIndexer:
                             "snippet": snippet,
                         }
                         self._unsaved_changes += 1
+                        # Invalidate cache
+                        self._matrix_cache = None
+                        self._paths_cache = None
                         print(f"[INDEXED] {path.split('::')[-1]}")
 
                     if self._unsaved_changes >= SAVE_INTERVAL:
@@ -368,8 +377,12 @@ class MatryoshkaIndexer:
 
             # Prepare Matrix
             # NOTE: For massive indices, use HNSW (faiss/chroma). For <100k vectors, numpy is fine.
-            paths = list(self.index.keys())
-            matrix = np.stack([d["vector"] for d in self.index.values()])
+            if self._matrix_cache is None or self._paths_cache is None:
+                self._paths_cache = list(self.index.keys())
+                self._matrix_cache = np.stack([d["vector"] for d in self.index.values()])
+
+            paths = self._paths_cache
+            matrix = self._matrix_cache
 
             # --- STAGE 1: Low-Res Shortlist (64 dims) ---
             q_short = q_vec[:SHORTLIST_DIM]


### PR DESCRIPTION
💡 What: Implemented matrix caching in `MatryoshkaIndexer`.
🎯 Why: The `search` method was rebuilding the numpy matrix from the index dictionary on every call, causing unnecessary overhead (~0.1s for 50k vectors).
📊 Impact: Reduces subsequent search latency by eliminating the matrix construction step. Benchmark showed a reduction from ~0.27s to ~0.17s per search for 50k vectors (37% improvement).
🔬 Measurement: Validated using a custom benchmark script `benchmark_search.py` (created and then deleted) which measured search time with 50k dummy vectors.


---
*PR created automatically by Jules for task [7929309514397445870](https://jules.google.com/task/7929309514397445870) started by @Fandry96*